### PR TITLE
Allow long menu rows to wrap naturally

### DIFF
--- a/styles/inspect.css
+++ b/styles/inspect.css
@@ -230,7 +230,6 @@
     color: #000;
     display: block;
     font-size: 13px;
-    height: 22px;
     line-height: 22px;
     padding: 0 15px;
     text-decoration: none;


### PR DESCRIPTION
This pull request removes the fixed `height` property on the submenu rows to allow long lines to wrap naturally. This addresses #7. When long lines wrap it looks like this: 

![wrap](http://f.cl.ly/items/382Z1q1K081f1a3k1l3E/Screen%20Shot%202013-07-18%20at%2010.25.56%20AM.png)

Note that ideally menu would stretch horizontally to accommodate the longer entry. Unfortunately this seems... hard. Currently the submenu is displayed with `position: absolute` which allows it to be positioned w.r.t. its parent div, which in this case is the main popover. The problem is that even if it did stretch, it might stretch too much and run into the right-hand window edge, which brings us back to the original problem.

Consequently, the perfect solution would 1) allow the window to stretch; 2) to have it's default position be a constant left-offset from the parent window; but 3) allow the left-offset to bleed outside of the main popover if the menu would otherwise bleed outside of the window. Whipping this up from scratch is probably more trouble than it's immediately worth, given that wrapping the line seems like a tolerable workaround. An alternative path forward would be to re-use the Brackets popup menu infrastructure, which should obey this approximate logic. I'll call that future work...
