### PR TITLE
Fixed issue #11- "[L10N][Japanese]: Overlocalized Edge Inspect extension on Japanese OS"

### DIFF
--- a/nls/strings.js
+++ b/nls/strings.js
@@ -37,7 +37,6 @@ define(function (require, exports, module) {
     // TODO: dynamically populate the local prefix list below?
     module.exports = {
         root: true,
-        "fr": true,
-        "ja": true
+        "fr": true
     };
 });


### PR DESCRIPTION
Fixed issue #11- "[L10N][Japanese]: Overlocalized Edge Inspect extension on Japanese OS"

removed Japanese language entry from master strings index.  left the actual Japanese translations under `nls/ja`, so in the future, when we actually want Japanese strings in this extension, we just need to re-add this entry into `nls/strings.js`
