### PR TITLE
Fix Edge Code Issue #362- ""Need help?" link in Edge Inspect Getting Starting dialog no longer works"

### DIFF
--- a/nls/fr/strings.js
+++ b/nls/fr/strings.js
@@ -109,5 +109,5 @@ define({
 	"HOWTO_DIAGRAM_IMAGE": "img/EdgeInspectInstructionImage_FR.png",
 	"HOWTO_DIAGRAM_IMAGE_HIDPI": "img/EdgeInspectInstructionImage@2x_FR.png",
 	"INSPECT_showhowto": "Mise en route...",
-	"INSPECT_needhelp": "<a class=\"clickable-link\" data-href=\"http://forums.adobe.com/community/edge_inspect/report_a_problem\">Besoin d’aide ? Posez une question sur Adobe Community...</a>"
+	"INSPECT_needhelp": "<a href='http://forums.adobe.com/community/edge_inspect'>Besoin d’aide ? Posez une question sur Adobe Community...</a>"
 });

--- a/nls/ja/strings.js
+++ b/nls/ja/strings.js
@@ -109,5 +109,5 @@ define({
 	"HOWTO_DIAGRAM_IMAGE": "img/EdgeInspectInstructionImage.png",
 	"HOWTO_DIAGRAM_IMAGE_HIDPI": "img/EdgeInspectInstructionImage@2x.png",
 	"INSPECT_showhowto": "はじめに...",
-	"INSPECT_needhelp": "<a class=\"clickable-link\" data-href=\"http://forums.adobe.com/community/edge_inspect/report_a_problem\">アドビコミュニティで質問...</a>"
+	"INSPECT_needhelp": "<a href='http://forums.adobe.com/community/edge_inspect'>アドビコミュニティで質問...</a>"
 });

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -109,5 +109,5 @@ define({
     "HOWTO_DIAGRAM_IMAGE"                                    : "img/EdgeInspectInstructionImage.png",
     "HOWTO_DIAGRAM_IMAGE_HIDPI"                              : "img/EdgeInspectInstructionImage@2x.png",
     "INSPECT_showhowto"                                      : "Getting started...",
-    "INSPECT_needhelp"                                       : "<a class=\"clickable-link\" data-href=\"http://forums.adobe.com/community/edge_inspect/report_a_problem\">Need help? Ask the Adobe Community...</a>"
+    "INSPECT_needhelp"                                       : "<a href='http://forums.adobe.com/community/edge_inspect'>Need help? Ask the Adobe Community...</a>"
 });


### PR DESCRIPTION
Fix Edge Code [Issue #362](https://git.corp.adobe.com/edge/edge-code/issues/362)\- ""Need help?" link in Edge Inspect Getting Starting dialog no longer works"

Deprecating clickable-link for href
